### PR TITLE
Add PlatformIO config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# PlatformIO build directory
+.pio/
+# VS Code settings
+.vscode/

--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ automatically every five minutes.
 
 ### PlatformIO
 
-Alternatively you can use [PlatformIO](https://platformio.org/):
+Alternatively you can use [PlatformIO](https://platformio.org/).  A ready-made
+`platformio.ini` is included in this repository:
 
 ```ini
 [env:sunton_esp32_display]
@@ -143,9 +144,9 @@ lib_deps =
   bblanchon/ArduinoJson
 ```
 
-Adjust the board definition if PlatformIO has an entry for `esp32-2432s032c`.
-Place `src` and `include` directories into the PlatformIO project and build
-with `pio run` and upload with `pio run -t upload`.
+Open the project folder in VS Code with the PlatformIO extension and click
+**Upload** to flash the firmware.  Adjust the `board` setting if PlatformIO has
+a specific definition for `esp32-2432s032c`.
 
 ## Usage
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,8 @@
+[env:sunton_esp32_display]
+platform = espressif32
+board = esp32dev
+framework = arduino
+monitor_speed = 115200
+lib_deps =
+  bodmer/TFT_eSPI
+  bblanchon/ArduinoJson


### PR DESCRIPTION
## Summary
- add `platformio.ini` with ESP32 dev board config
- update README with PlatformIO usage instructions
- add `.gitignore` for PlatformIO and VS Code artifacts

## Testing
- `pio --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_688d13085160832b9b3eab728a5608da