### PR TITLE
feat: add SD card boot logo

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -13,6 +13,7 @@ platform = espressif32
 board = esp32dev
 framework = arduino
 monitor_speed = 115200
-lib_deps = 
-	bodmer/TFT_eSPI
-	bblanchon/ArduinoJson
+lib_deps =
+        bodmer/TFT_eSPI
+        bblanchon/ArduinoJson
+        bitbank2/PNGdec


### PR DESCRIPTION
## Summary
- display boot logo from SD card during startup when available
- add PNG decoding support and SD card content check

## Testing
- `pio run` *(fails: command not found)*
- `pip install platformio` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688ea1a16950832b9a56c91c6fc1e671