### PR TITLE
Use JsonDocument instead of deprecated StaticJsonDocument

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -616,7 +616,7 @@ bool fetchAnkerData(float &batteryPercent, float &dailyGeneration,
   http.begin(wifiClient, ANKER_AUTH_URL);
   http.addHeader("Content-Type", "application/json");
   // Build JSON body for login; credentials defined in secrets.h
-  StaticJsonDocument<256> loginDoc;
+  JsonDocument loginDoc(256);
   loginDoc["userAccount"] = ANKER_USER;
   loginDoc["password"] = ANKER_PASSWORD;
   loginDoc["country"] = ANKER_COUNTRY;
@@ -631,7 +631,7 @@ bool fetchAnkerData(float &batteryPercent, float &dailyGeneration,
   // Parse authentication response
   String response = http.getString();
   http.end();
-  StaticJsonDocument<1024> authDoc;
+  JsonDocument authDoc(1024);
   DeserializationError err = deserializeJson(authDoc, response);
   if (err) {
     Serial.println("Failed to parse auth response");
@@ -660,7 +660,7 @@ bool fetchAnkerData(float &batteryPercent, float &dailyGeneration,
   //  "daily_consumption": 2.10,
   //  "generation_curve": [24 floats ...],
   //  "consumption_curve": [24 floats ...] }.
-  StaticJsonDocument<4096> energyDoc;
+  JsonDocument energyDoc(4096);
   err = deserializeJson(energyDoc, energyResponse);
   if (err) {
     Serial.println("Failed to parse energy response");
@@ -712,7 +712,7 @@ bool fetchSmartmeterData(float &batteryPercent, float &dailyGeneration,
   }
   String response = http.getString();
   http.end();
-  StaticJsonDocument<4096> doc;
+  JsonDocument doc(4096);
   DeserializationError err = deserializeJson(doc, response);
   if (err) {
     Serial.println("Failed to parse smart‑meter response");


### PR DESCRIPTION
## Summary
- replace outdated `StaticJsonDocument` uses with `JsonDocument`

## Testing
- `pio run` *(fails: command not found)*
- `pip install --user platformio` *(fails: Could not connect to proxy)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688ea406b558832ba2f7a2842499fe0e